### PR TITLE
Update nu from 0.10 to 0.16, fix a type conversion compilation error,…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nu_plugin_id3"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["notryanb@gmail.com <notryanb@gmail.com>"]
 edition = "2018"
 description = "An id3 reading plugin for Nushell"
@@ -12,7 +12,7 @@ exclude = ["images"]
 
 [dependencies]
 id3 = "0.5"
-nu-plugin = "0.10.0"
-nu-protocol = "0.10.0"
-nu-source = "0.10.0"
-nu-errors = "0.10.0"
+nu-plugin = "0.16.0"
+nu-protocol = "0.16.0"
+nu-source = "0.16.0"
+nu-errors = "0.16.0"

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -42,7 +42,7 @@ pub fn parse_id3_tag(value: Value) -> Result<Value, ShellError> {
 
                     dict.insert_untagged(
                         "duration",
-                        tag.duration().map_or_else(|| UntaggedValue::nothing(), |duration| UntaggedValue::duration(duration as u64))
+                        tag.duration().map_or_else(|| UntaggedValue::nothing(), |duration| UntaggedValue::duration(duration as i64))
                     );
 
                     dict.insert_untagged(


### PR DESCRIPTION
- Updates nu dependency from `0.10.0` to `0.16.0`
- Fixes compilation error for mapping `duration` id3 field
- Increment package version to `0.1.1` 